### PR TITLE
Fixed Guzzle 6 exception

### DIFF
--- a/src/kayako/services/BaseService.php
+++ b/src/kayako/services/BaseService.php
@@ -65,8 +65,8 @@ abstract class BaseService
         $requestParams['query'] = ['e' => $path];
         $params = array_merge($params, $this->getUrlSignParams());
         if (in_array($method, ['post', 'put'])) {
-            $requestParams['body'] = $params;
-            $requestParams['form_params'] = $params;
+            $requestParams['headers']['Content-Type'] = 'application/x-www-form-urlencoded';
+            $requestParams['body'] = http_build_query($params, '', '&');
         } else {
             $requestParams['query'] = array_merge($requestParams['query'], $params);
         }


### PR DESCRIPTION
Hello,

I want to apologize; there was a bit of oversight in my last pull request, which was made apparent when I corrected the composer dependency in my project. In Guzzle 6, it was actually throwing an exception. Instead of relying on internal Guzzle behavior, this pull request instead just encodes the form content manually, bypassing the inconsistencies altogether.