### PR TITLE
Handle XML decoding failures

### DIFF
--- a/src/kayako/services/BaseService.php
+++ b/src/kayako/services/BaseService.php
@@ -104,6 +104,11 @@ abstract class BaseService
     {
         libxml_use_internal_errors(true);
         $xml = simplexml_load_string($response);
+        if ($xml === false) {
+            $message = sprintf('Kayako responded with an invalid body (%s).', $response);
+            $this->logger->error($message);
+            throw new ServerException($message);
+        }
         $result = [];
         foreach ($xml as $child) {
             /** @var Model $modelClas */


### PR DESCRIPTION
Hello,

I've run into a few edge cases where Kayako seems to return an exception message with an OK status code, resulting in the response parsing failing. This adds handling for the XML decoding failures, and throws an exception to be handled upstream.